### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server that exposes tools for interacting with the Bitpanda API. This server allows programmatic access to Bitpanda features like trades, wallets, and transactions via the MCP protocol.
 
+<a href="https://glama.ai/mcp/servers/@matteoantoci/mcp-bitpanda">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@matteoantoci/mcp-bitpanda/badge" alt="Bitpanda Server MCP server" />
+</a>
+
 ## Prerequisites
 
 - Node.js (v18 or later recommended)


### PR DESCRIPTION
This PR adds a badge for the [MCP Bitpanda Server](https://glama.ai/mcp/servers/@matteoantoci/mcp-bitpanda) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@matteoantoci/mcp-bitpanda">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@matteoantoci/mcp-bitpanda/badge" alt="Bitpanda Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.